### PR TITLE
BLD: use bluesky-base for conda builds

### DIFF
--- a/.github/workflows/build_and_upload.yml
+++ b/.github/workflows/build_and_upload.yml
@@ -11,7 +11,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 
@@ -54,7 +54,7 @@ jobs:
           --keep-old-work
 
     - name: Upload the built package as an artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: psdaq-control-minimal conda package
         path: ~/conda-bld
@@ -78,7 +78,7 @@ jobs:
         shell: bash --login -eo pipefail {0}
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 0
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -21,7 +21,7 @@ requirements:
       - setuptools-scm
     run:
       - python >=3.6
-      - bluesky
+      - bluesky-base
       - ophyd
       - pyzmq
 

--- a/generate_minimal_package.sh
+++ b/generate_minimal_package.sh
@@ -12,7 +12,7 @@ echo "Building minimal psdaq.control package"
 mkdir psdaq
 echo "from ._version import __version__" > psdaq/__init__.py
 # This will be overwritten by setuptools_scm, but it can help in testing
-echo "__version__ = '${TAG}'" > psdaq/_version.py
+echo "__version__ = version = '${TAG}'" > psdaq/_version.py
 mkdir psdaq/control
 cp lcls2/psdaq/psdaq/control/* psdaq/control
 echo "Done"


### PR DESCRIPTION
## Description
Use Bluesky-base for conda builds, avoiding matplotlib and qt dependencies

## Motivation and Context
get out of here qt6

## How Has This Been Tested?
This PR's CI?

## Where Has This Been Documented?
This PR